### PR TITLE
Fix color variable in YouTube downloader script

### DIFF
--- a/youtube_downloader.sh
+++ b/youtube_downloader.sh
@@ -12,6 +12,7 @@ YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+BLUE='\033[0;34m'
 
 # === Help screen ===
 print_help() {


### PR DESCRIPTION
## Summary
- define `BLUE` color code used in help text

## Testing
- `bash -n youtube_downloader.sh`
- `bash youtube_downloader.sh --help | head`

------
https://chatgpt.com/codex/tasks/task_e_6846e8f7b53483208e7bc911612aabc7