### PR TITLE
Add bats test for help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@ This is my script for downloading videos from youtube
 
 ## Dependencies
 The script relies on `yt-dlp`, `jq`, `fzf`, `parallel`, and `notify-send`. It may not work without these tools installed.
+
+## Testing
+To run the test suite, execute:
+
+```bash
+bats tests
+```

--- a/tests/test_help.bats
+++ b/tests/test_help.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "display help" {
+  run ../youtube_downloader.sh --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"YouTube Downloader - CLI Options"* ]]
+}


### PR DESCRIPTION
## Summary
- add Bats test to verify help text
- document how to run tests with `bats`

## Testing
- `bats tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f161f2c483208285c20226e6b6e5